### PR TITLE
新增磚坯的切石機配方，使其可被自動化生產

### DIFF
--- a/.pakku/overrides/kubejs/data/kots/recipes/more_recipe/unfired_clay_brick_from_clay_ball.json
+++ b/.pakku/overrides/kubejs/data/kots/recipes/more_recipe/unfired_clay_brick_from_clay_ball.json
@@ -1,0 +1,8 @@
+{
+  "type": "minecraft:stonecutting",
+  "count": 1,
+  "ingredient": {
+    "item": "minecraft:clay_ball"
+  },
+  "result": "ultramarine:unfired_clay_brick"
+}


### PR DESCRIPTION
### 問題

`ultramarine:unfired_clay_brick`（磚坯）在包內僅有一條合成配方：

```
CCC (C = minecraft:clay_ball)
```

與  `tofucraft:foodplate` (食物盤子) 的合成配方完全相同。

手動合成時玩家可以在配方書中選擇要合成的產物，兩者都能取得，因此手動流程沒有問題。但自動化合成（如 Create 機械動力合成器）無法指定配方，相同形狀下會默認產出 食物盤子。

由於磚坯沒有其他取得途徑，這導致磚坯目前無法自動化生產，只能手動合成。

### 修改內容

新增切石機配方：

`kubejs/data/kots/recipes/more_recipe/unfired_clay_brick_from_clay_ball.json`

```json
{
 "type": "minecraft:stonecutting",
 "count": 1,
 "ingredient": {
 "item": "minecraft:clay_ball"
 },
 "result": "ultramarine:unfired_clay_brick"
}
```

### 理由

Create 的動力鋸可​​執行原版 `minecraft:stonecutting` 配方，因此本配方在切石機與動力鋸上均可使用，磚坯得以進入自動化生產線。

### 測試

已在 v5.5.0 實測：

- 切石機：黏土球 → 磚坯，正常產出
- Create 動力鋸：正常產出

### 備註

未加入 `category` / `group` 字段——包內既有的 `more_recipe` 條目帶有這兩個字段，但均非 stonecutting 類型；`group` 對 stonecutting 無實際作用，故沿用 `clay_saucer` 的精簡寫法。如需對齊既有風格可以補上。

其實我覺得也能修改 `tofucraft:foodplate` 改成 圓形 樣子 (增加一個黏土球)
```
 C 
C C
 C 
```